### PR TITLE
Added host and port trimmer to reduce chance of error

### DIFF
--- a/CryptoNoteMiner/Main.cs
+++ b/CryptoNoteMiner/Main.cs
@@ -174,6 +174,10 @@ namespace VFCNMiner
 
         void startMiningProcesses()
         {
+    // Remove any leading or ending spaces - typical occurs when using copy and paste and will result in the mining process failing to start.
+            textBoxPoolHost.Text = textBoxPoolHost.Text.Trim();
+            textBoxPoolPort.Text = textBoxPoolPort.Text.Trim();
+            
             var args = new ArrayList(new[] { 
                 "-a cryptonight",
                 "-o stratum+tcp://" + textBoxPoolHost.Text + ':' + textBoxPoolPort.Text,
@@ -283,6 +287,10 @@ namespace VFCNMiner
 
         void startGPUMiningProcesses()
         {
+        // Remove any leading or ending spaces - typical occurs when using copy and paste and will result in the mining process failing to start.
+            textBoxPoolHost.Text = textBoxPoolHost.Text.Trim();
+            textBoxPoolPort.Text = textBoxPoolPort.Text.Trim();
+            
             var args = new ArrayList(new[] {
                 "-o stratum+tcp://" + textBoxPoolHost.Text + ':' + textBoxPoolPort.Text,
                 "-u " + address,


### PR DESCRIPTION
Added trim in case user pastes the host or port into the textbox with a space at the end. It's not easily visible and results in the miner process failing to start with no indication why